### PR TITLE
Unresolved dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "MIT License"
             :url "http://dd.mit-license.org"}
   :dependencies [[org.clojure/clojure "1.4.0"]
-                 [com.cemerick/friend "0.1.2"]
+                 [com.cemerick/friend "0.1.3"]
                  [ring "1.1.6"]
                  [clj-http "0.5.3"]
                  [cheshire "4.0.2"]]


### PR DESCRIPTION
The openid4java artifact in cemerick/friend referred to a repository that is not available anymore. This was fixed in friend by manually removing the dependency and using an alternative repository. See the following commit: https://github.com/cemerick/friend/commit/d5c9b63f4ac02d403a766e3dafae700c54eb4717#project.clj
The problem is resolved if the current friend version (0.1.3) is used. The tests are passing, but I am not sure if it is actually safe to bump the version.

Output of `lein deps`

> Could not find artifact com.google.code.guice:guice:pom:2.0 in central >(http://repo1.maven.org/maven2)
> Could not find artifact com.google.code.guice:guice:pom:2.0 in clojars (https://clojars.org/repo/)
> Could not find artifact com.google.code.guice:guice:pom:2.0 in stuart (http://stuartsierra.com/maven2)
> Could not transfer artifact com.google.code.guice:guice:pom:2.0 from/to guice (http://guice-maven.googlecode.com/svn/trunk): Not authorized, ReasonPhrase:Authorization Required.
> Could not find artifact com.google.code.guice:guice:pom:2.0 in alchim.snapshots (http://alchim.sf.net/download/snapshots)
> Check :dependencies and :repositories for typos.
> It's possible the specified jar is not in any repository.
> If so, see "Free-floating Jars" under http://j.mp/repeatability
> Could not resolve dependencies```
