### PR TITLE
optionally parse refresh tokens from authorization code exchange

### DIFF
--- a/src/friend_oauth2/util.clj
+++ b/src/friend_oauth2/util.clj
@@ -28,6 +28,14 @@
   [{body :body}]
   (-> body (parse-string true) :access_token))
 
+(defn make-access-token-parser
+  "creates an fn [resp] that applies the provided parser and
+   wraps its result (if available) in a map"
+  [parser]
+  (fn [token-resp]
+    (when-let [t (extract-access-token token-resp)]
+      {:access-token t})))
+
 (defn get-access-token-from-params
   "Alternate function to allow retrieve
    access_token when passed in as form params."

--- a/src/friend_oauth2/workflow.clj
+++ b/src/friend_oauth2/workflow.clj
@@ -17,15 +17,18 @@
          (or (:login-uri config) (-> request ::friend/auth-config :login-uri)))))
 
 (defn- request-token
-  "POSTs request to OAauth2 provider for authorization token."
-  [{:keys [uri-config access-token-parsefn]} code]
+  "Exchanges authorization code for access token & refresh token if provided. Response
+   from provider is parsed with response-parse-fn if provided, otherwise access-token-parsefn
+   is used if given."
+  [{:keys [uri-config access-token-parsefn response-parse-fn]} code]
   (let [access-token-uri (:access-token-uri uri-config)
-        query-map        (merge {:grant_type "authorization_code"}
-                                (util/replace-authz-code access-token-uri code))
-        token-url        (assoc access-token-uri :query query-map)
-        token-response   (client/post (:url token-url) {:form-params (:query token-url)})
-        token-parse-fn   (or access-token-parsefn util/extract-access-token)]
-    (token-parse-fn token-response)))
+        query-map        (assoc (util/replace-authz-code access-token-uri code)
+                           :grant_type "authorization_code")
+        token-parse-fn (or response-parse-fn
+                           (util/make-access-token-parser (or access-token-parsefn
+                                                                util/extract-access-token)))]
+    (token-parse-fn (client/post (:url access-token-uri)
+                                 {:form-params query-map}))))
 
 (defn- redirect-to-provider!
   "Redirects user to OAuth2 provider. Code should be in response."
@@ -48,9 +51,9 @@
             session-state        (util/extract-anti-forgery-token request)]
         (if (and (not (nil? code))
                  (= state session-state))
-          (when-let [access-token (request-token config code)]
+          (when-let [token (request-token config code)]
             (when-let [auth-map ((:credential-fn config default-credential-fn)
-                                 {:access-token access-token})]
+                                 token)]
               (vary-meta auth-map merge {::friend/workflow :oauth2
                                          ::friend/redirect-on-auth? true
                                          :type ::friend/auth})))


### PR DESCRIPTION
`workflow/request-token` can be passed a `response-parse-fn` (superceding
`access-token-parsefn`), allowing values in addition to the access token to be parsed (e.g. refresh token).  For example, for google’s oauth2

``` clojure
(def friend-config
  {:allow-anon? true
   :workflows   [(oauth2/workflow
                  {:client-config client-config
                   :uri-config uri-config
                   :credential-fn credential-fn
                   :response-parse-fn
                   (fn [req]
                     (when-let [response
                                (some-> req :body (parse-string true))]
                       {:access-token (:access_token response)
                        :refresh-token (:refresh_token response)}))})]})
```

`response-parse-fn` should return a map containing parsed vals. Addresses #20
