### PR TITLE
Throw an exception when any query params are nil in `format-authn-uri`.

### DIFF
--- a/src/friend_oauth2/util.clj
+++ b/src/friend_oauth2/util.clj
@@ -13,9 +13,13 @@
 (defn format-authn-uri
   "Formats the client authentication uri"
   [{{:keys [query url]} :authentication-uri} anti-forgery-token]
-  (->> (assoc query :state anti-forgery-token)
-       ring-codec/form-encode
-       (str url "?")))
+  (let [missing-keys (keys (filter (comp nil? val) query))]
+    (do
+      (when-not (empty? missing-keys)
+        (throw (Exception. (str "Missing values for query params:" missing-keys))))
+      (->> (assoc query :state anti-forgery-token)
+        ring-codec/form-encode
+        (str url "?")))))
 
 (defn replace-authz-code
   "Formats the token uri with the authorization code"

--- a/test/friend_oauth2/util_facts.clj
+++ b/test/friend_oauth2/util_facts.clj
@@ -38,6 +38,12 @@
                           "state"        "anti-forgery-token"}))
 
 (fact
+  "Throws an exception for nil query param values"
+  (oauth2-util/format-authn-uri
+    {:authentication-uri {:query {:foo nil} :url "https://foo.com"}} "token") =>
+    (throws Exception))
+
+(fact
  "Replaces the authorization code"
  ((oauth2-util/replace-authz-code (uri-config-fixture :access-token-uri) "my-code") :code)
  => "my-code")


### PR DESCRIPTION
It seems more user friendly than returning

```
No implementation of method: :form-encode* of protocol: #'ring.util.codec/FormEncodeable found for class: nil
```

Which is what happens when one forgets to define e.g. google client id.
